### PR TITLE
Fix for large project download failures

### DIFF
--- a/docker-compose-gunicorn.yml
+++ b/docker-compose-gunicorn.yml
@@ -22,7 +22,7 @@ services:
         cron
         crontab /phylobook/crontab_process_fasta
         python manage.py collectstatic --noinput
-        gunicorn -w 2 -b 0.0.0.0:${WEB_PORT} phylobook.wsgi:application
+        gunicorn -t 600 -w 2 -b 0.0.0.0:${WEB_PORT} phylobook.wsgi:application
 
     volumes:
       - .:/phylobook

--- a/phylobook/projects/views.py
+++ b/phylobook/projects/views.py
@@ -368,7 +368,7 @@ def downloadProjectFiles(request, name):
     if project and (request.user.has_perm('projects.change_project', project) or request.user.has_perm('projects.view_project', project)):
         response = HttpResponse(content_type='application/x-gzip')
         response['Content-Disposition'] = 'attachment; filename=' + name + '-' + time.strftime("%Y%m%d-%H%M%S") + '.tar.gz'
-        tarred = tarfile.open(fileobj=response, mode='w:gz')
+        tarred = tarfile.open(fileobj=response, mode='w:gz', compresslevel=1)
         tarred.add(os.path.join(PROJECT_PATH, name), arcname=name)
         tarred.close()
     else:


### PR DESCRIPTION
Hi there


Jim reported on an issue where some project files cannot be downloaded.  Upon inspection, I found two reasons for this:

1. The -t flag for gunicorn defaults to 30 seconds for the creation of the project archive and download - killed silently after 30 seconds
2. Related to 1, the default for tarfile is to use level 9 compression

As an aside, it appears the way downloads are handled, is to dump the binary blob into an array on the browser's end and then dump it to disk. This is an issue when the downloads are > 2GB, where the browser fails silently (unlikely to happen, but something to keep in mind) 

The fix for (1) is increasing this timeout to something more reasonable (600 seconds).  I've added `compresslevel=1` to the archive creation part to speed this process up.  

I have done limited testing on this, and it appears to work. 